### PR TITLE
new AWSInstanceID in agent config for pull instanceId from aws metadata

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/internal/config"
@@ -37,6 +39,18 @@ func NewAgent(config *config.Config) (*Agent, error) {
 		}
 
 		config.Tags["host"] = a.Config.Agent.Hostname
+	}
+
+	if a.Config.Agent.AWSInstanceID {
+
+		svc := ec2metadata.New(session.New())
+		if svc.Available() {
+			instanceid, err := svc.GetMetadata("instance-id")
+			if err != nil {
+				return nil, err
+			}
+			config.Tags["InstanceId"] = instanceid
+		}
 	}
 
 	return a, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -139,6 +139,9 @@ type AgentConfig struct {
 	Quiet        bool
 	Hostname     string
 	OmitHostname bool
+
+	//Get AWS InstancesID from metadata
+	AWSInstanceID bool
 }
 
 // Inputs returns a list of strings of the configured inputs.


### PR DESCRIPTION
- new AWSInstanceID in agent config, this allow aws instance to pull metadata and setup the instanceid tag